### PR TITLE
Fixed typo in GrayjaySettings.cs: 'previouw' corrected to 'preview'

### DIFF
--- a/Grayjay.ClientServer/Settings/GrayjaySettings.cs
+++ b/Grayjay.ClientServer/Settings/GrayjaySettings.cs
@@ -43,7 +43,7 @@ namespace Grayjay.ClientServer.Settings
             [SettingsField("Search history", SettingsField.TOGGLE, "May require restart", 3)]
             public bool SearchHistory { get; set; } = true;
 
-            [SettingsField("Preview Feed Items", SettingsField.TOGGLE, "When the previouw feedstyle is used, if items should automatically preview.", 5)]
+            [SettingsField("Preview Feed Items", SettingsField.TOGGLE, "When the preview feedstyle is used, if items should automatically preview.", 5)]
             public bool PreviewFeedItems { get; set; } = true;
 
             [SettingsField("Progress Bar", SettingsField.TOGGLE, "If a historical progress bar should be shown", 6)]


### PR DESCRIPTION
Fixed typo in GrayjaySettings.cs: 'previouw' corrected to 'preview'.
![image](https://github.com/user-attachments/assets/11de14ad-479e-48a9-a2bf-6e81fb50d27a)
Similar set of strings that I used as a reference:
![image](https://github.com/user-attachments/assets/9a013b8b-d62a-4fdd-8a83-e7920fbcf37b)
