### PR TITLE
Add Grayjay.Desktop.Web Flake

### DIFF
--- a/Grayjay.Desktop.Web/alejandra.toml
+++ b/Grayjay.Desktop.Web/alejandra.toml
@@ -1,0 +1,1 @@
+indentation = "Tabs"

--- a/Grayjay.Desktop.Web/flake.lock
+++ b/Grayjay.Desktop.Web/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1734649271,
+        "narHash": "sha256-4EVBRhOjMDuGtMaofAIqzJbg4Ql7Ai0PSeuVZTHjyKQ=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "d70bd19e0a38ad4790d3913bf08fcbfc9eeca507",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/Grayjay.Desktop.Web/flake.nix
+++ b/Grayjay.Desktop.Web/flake.nix
@@ -1,0 +1,48 @@
+{
+	description = "Web interface for Grayjay Desktop";
+
+	inputs = {
+		nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+	};
+
+	outputs = {
+		self,
+		nixpkgs,
+	}: let
+		system = "x86_64-linux";
+		pkgs = nixpkgs.legacyPackages.${system};
+		version = "0.0.0";
+
+		sourceRepo =
+			pkgs.fetchFromGitHub {
+				owner = "futo-org";
+				repo = "Grayjay.Desktop";
+				rev = "3dfebc3af34d428ece9ef764914af2df03a8ee94";
+				hash = "sha256-BA1IsSUciHuvUADitjed9Wf44V1Xq8iN1tw7D722aLk=";
+			};
+	in {
+		packages.${system}.default = let
+		in
+			pkgs.buildNpmPackage {
+				name = "grayjay-desktop-web";
+				inherit version;
+
+				src = "${sourceRepo}/Grayjay.Desktop.Web";
+
+				# TODO: port package.json to flake
+				npmDepsHash = "sha256-pTEbMSAJwTY6ZRriPWfBFnRHSYufSsD0d+hWGz35xFM=";
+
+				postBuild = ''
+				  cp -r ./dist $out/
+				'';
+
+				fixupPhase = ''
+				  rm -rf $out/lib
+				'';
+
+				meta = {
+					description = "Grayjay Desktop's web-based interface";
+				};
+			};
+	};
+}


### PR DESCRIPTION
I've written and tested a flake.nix for Grayjay.Desktop.Web

It's not quite up to my standards, but it evaluates as expected. You can verify this to your own satisfaction by running `nix build ./Grayjay.Desktop.Web` from the repo's root and digging through the `result` symlink. My intentions are to import this derivation as-is into the final packaged output of Grayjay.Desktop as a whole, a la `cp -r ${pkgs.grayjay-desktop-web} $out/bin/wwwroot`.

> [!TIP]
> ### To the maintainers:
> I'll be following the "branch stacking" convention for these flakes, so it may be more convenient to merge a different branch, which should be mentioned below.

> [!NOTE]
> [Alejandra](https://github.com/kamadorueda/alejandra), my formatter of choice, only added support for `alejandra.toml` in v3.1.0

> [!CAUTION]
> ### Concerning `$out/lib`:
> `pkgs,lib.buildNpmPackage` includes node_modules in `$out/lib`, which takes up an obscene amount of space and is afaict totally unnecesary. `fixupPhase` is a hacky workaround for this and I totally intend to fix it properly.