### PR TITLE
Up and down keys change volume only if video focused

### DIFF
--- a/Grayjay.Desktop.Web/src/components/player/VideoPlayerView/index.tsx
+++ b/Grayjay.Desktop.Web/src/components/player/VideoPlayerView/index.tsx
@@ -932,7 +932,7 @@ const VideoPlayerView: Component<VideoProps> = (props) => {
             document.exitFullscreen();
             setIsFullscreen(false);
         } else {
-            containerRef?.requestFullscreen();
+            containerRef?.requestFullscreen().then(() => containerRef?.focus());
             setIsFullscreen(true);
         }
     };
@@ -983,8 +983,10 @@ const VideoPlayerView: Component<VideoProps> = (props) => {
             }} 
             style={{ 
                 ... props.style,
-                cursor: areControlsVisible() ? undefined : "none"
+                cursor: areControlsVisible() ? undefined : "none",
+                outline: 0
             }} 
+            tabindex="-1"
             onMouseMove={handleMouseMove}
             onMouseLeave={hideControls}
             onDblClick={handleDblClick}>
@@ -1009,6 +1011,7 @@ const VideoPlayerView: Component<VideoProps> = (props) => {
 
                 <PlayerControlsView
                     chapters={props.chapters}
+                    controlEventContainer={containerRef}
                     video={props.video}
                     duration={duration()}
                     position={position()}


### PR DESCRIPTION
Enables vertical scrolling using the Up and Down arrow keys on the keyboard if the video is not focused, which previously did not work in most of the UI. This improves accessibility for keyboard users and is consistent with other major video apps such as YouTube, Crunchyroll, and Twitch. To supplement, I focus the video container when the user enters fullscreen so the arrows control volume at that point.

I'm not a big fan of passing a child element a reference to an ancestor, but this pattern is consistent with code elsewhere in the app. I would prefer to factor the event listeners out of the `PlayerControlsView` but I went with a lighter touch here to start.

If preserving the previous global functionality as an option is desired, I could add a user setting for toggling this.