### PR TITLE
fix: truncate download filenames to prevent 'filename too long' on Windows (#875)

### DIFF
--- a/Grayjay.ClientServer/Extensions.cs
+++ b/Grayjay.ClientServer/Extensions.cs
@@ -196,6 +196,24 @@ namespace Grayjay.ClientServer
                 fileName = fileName.Replace(invalidChar, '_');
             return fileName;
         }
+
+        // Windows MAX_PATH is 260; reserve some room for the directory prefix.
+        private const int MaxFileNameLength = 200;
+        /// <summary>
+        /// Truncates a file name (after sanitization) so that the base name fits within
+        /// <see cref="MaxFileNameLength"/> characters, preserving the extension.
+        /// </summary>
+        public static string TruncateFileName(this string fileName)
+        {
+            if (fileName.Length <= MaxFileNameLength)
+                return fileName;
+
+            string ext = Path.GetExtension(fileName);   // e.g. ".mp4"
+            string baseName = Path.GetFileNameWithoutExtension(fileName);
+            int allowedBase = MaxFileNameLength - ext.Length;
+            if (allowedBase < 1) allowedBase = 1;
+            return baseName.Substring(0, Math.Min(baseName.Length, allowedBase)) + ext;
+        }
         public static string SanitizeFileNameWithPath(this string path)
         {
             string dirName = Path.GetDirectoryName(path);

--- a/Grayjay.ClientServer/Models/Downloads/VideoDownload.cs
+++ b/Grayjay.ClientServer/Models/Downloads/VideoDownload.cs
@@ -321,7 +321,7 @@ namespace Grayjay.ClientServer.Models.Downloads
                 var representation = videoRepresentations?.FirstOrDefault();
                 var mimeType = representation?.MimeType ?? VideoSource.Container;
 
-                VideoFileName = $"{VideoDetails.ID.Value} [{VideoSource.Width}x{VideoSource.Height}].{VideoHelper.VideoContainerToExtension(mimeType)}".SanitizeFileName();
+                VideoFileName = $"{VideoDetails.ID.Value} [{VideoSource.Width}x{VideoSource.Height}].{VideoHelper.VideoContainerToExtension(mimeType)}".SanitizeFileName().TruncateFileName();
                 VideoFilePath = Path.Combine(downloadDir, VideoFileName);
             }
             string audioDash = (AudioSource is DashManifestRawAudioSource dAudioSource) ? dAudioSource.Generate() : null;
@@ -331,12 +331,12 @@ namespace Grayjay.ClientServer.Models.Downloads
                 var representation = audioRepresentations?.FirstOrDefault();
                 var mimeType = representation?.MimeType ?? AudioSource.Container;
 
-                AudioFileName = $"{VideoDetails.ID.Value} [{AudioSource.Language}-{AudioSource.Bitrate}].{VideoHelper.AudioContainerToExtension(mimeType)}".SanitizeFileName();
+                AudioFileName = $"{VideoDetails.ID.Value} [{AudioSource.Language}-{AudioSource.Bitrate}].{VideoHelper.AudioContainerToExtension(mimeType)}".SanitizeFileName().TruncateFileName();
                 AudioFilePath = Path.Combine(downloadDir , AudioFileName);
             }
             if(SubtitleSourcetoUse != null)
             {
-                SubtitleFileName = $"{VideoDetails.ID.Value} [{SubtitleSourcetoUse.Name}].{VideoHelper.SubtitleContainerToExtension(SubtitleSourcetoUse.Format)}".SanitizeFileName();
+                SubtitleFileName = $"{VideoDetails.ID.Value} [{SubtitleSourcetoUse.Name}].{VideoHelper.SubtitleContainerToExtension(SubtitleSourcetoUse.Format)}".SanitizeFileName().TruncateFileName();
                 SubtitleFilePath = Path.Combine(downloadDir, SubtitleFileName);
             }
             var progressLock = new Object();


### PR DESCRIPTION
## Problem

Twitch VOD IDs (and other long platform IDs) produce sanitized file names that, when combined with the download directory path, exceed Windows `MAX_PATH` (260 chars). This causes `ffmpeg.exe` to fail with `ERROR_FILENAME_EXCED_RANGE` ("The filename or extension is too long") when it tries to open the output file.

Reported in #875.

## Root cause

In `VideoDownload.cs`, file names are built as:
```
$"{VideoDetails.ID.Value} [{width}x{height}].{ext}".SanitizeFileName()
```

For Twitch VODs the ID value is a full URL (e.g. `https://www.twitch.tv/videos/…`). After sanitization the slashes become underscores, yielding a very long base name. Combined with the download directory prefix the total path easily exceeds 260 characters.

## Fix

Add a `TruncateFileName()` extension method in `Extensions.cs` that caps the base-name portion at 200 characters while preserving the file extension. Apply it after `SanitizeFileName()` for `VideoFileName`, `AudioFileName`, and `SubtitleFileName`.

```csharp
// before
VideoFileName = $"...".SanitizeFileName();

// after
VideoFileName = $"...".SanitizeFileName().TruncateFileName();
```

The 200-char cap leaves ample room for any reasonable download directory path while keeping the name human-readable.