### PR TITLE
Add grayjay:// protocol handler for external URL opening

### DIFF
--- a/Grayjay.ClientServer/Controllers/WindowController.cs
+++ b/Grayjay.ClientServer/Controllers/WindowController.cs
@@ -38,6 +38,19 @@ namespace Grayjay.ClientServer.Controllers
                 state.Ready = true;
                 StateWindow.StateReadyChanged(state, true);
             }
+            if (StateWebsocket.PendingStartupUrl != null)
+            {
+                var pendingUrl = StateWebsocket.PendingStartupUrl;
+                StateWebsocket.PendingStartupUrl = null;
+                StateWebsocket.OpenUrl(pendingUrl, 0);
+            }
+        }
+
+        [HttpGet]
+        public void OpenUrl(string url)
+        {
+            if (!string.IsNullOrEmpty(url))
+                StateWebsocket.OpenUrl(url, 0);
         }
 
 

--- a/Grayjay.ClientServer/States/StateWebsocket.cs
+++ b/Grayjay.ClientServer/States/StateWebsocket.cs
@@ -10,6 +10,8 @@ namespace Grayjay.ClientServer.States;
 
 public class StateWebsocket
 {
+    public static string? PendingStartupUrl { get; set; } = null;
+
     public static void SubscriptionGroupsChanged()
     {
         Task.Run(async () =>

--- a/Grayjay.Desktop.CEF/Info/Info.plist
+++ b/Grayjay.Desktop.CEF/Info/Info.plist
@@ -37,5 +37,16 @@
         <string>NSApplication</string>
         <key>NSSupportsAutomaticGraphicsSwitching</key>
         <true/>
+        <key>CFBundleURLTypes</key>
+        <array>
+            <dict>
+                <key>CFBundleURLName</key>
+                <string>Grayjay URL</string>
+                <key>CFBundleURLSchemes</key>
+                <array>
+                    <string>grayjay</string>
+                </array>
+            </dict>
+        </array>
     </dict>
 </plist>

--- a/Grayjay.Desktop.CEF/Program.cs
+++ b/Grayjay.Desktop.CEF/Program.cs
@@ -98,7 +98,7 @@ namespace Grayjay.Desktop
             Logger.i(nameof(Program), $"KillExistingProcessByPath duration {sw.ElapsedMilliseconds}ms");
         }
 
-        private static async Task<bool> TryOpenWindow()
+        private static async Task<bool> TryOpenWindow(string? startupUrl = null)
         {
             Stopwatch sw = Stopwatch.StartNew();
 
@@ -125,11 +125,18 @@ namespace Grayjay.Desktop
                     return false;
                 }
 
+                using HttpClient client = new HttpClient { Timeout = TimeSpan.FromMilliseconds(500) };
+
                 var url = $"http://127.0.0.1:{port}/Window/StartWindow";
                 Logger.i(nameof(Program), $"TryOpenWindow: " + url);
-
-                using HttpClient client = new HttpClient { Timeout = TimeSpan.FromMilliseconds(500) };
                 var response = await client.GetAsync(url);
+
+                if (response.IsSuccessStatusCode && startupUrl != null)
+                {
+                    var openUrl = $"http://127.0.0.1:{port}/Window/OpenUrl?url={Uri.EscapeDataString(startupUrl)}";
+                    Logger.i(nameof(Program), $"TryOpenWindow sending URL: " + openUrl);
+                    await client.GetAsync(openUrl);
+                }
 
                 return response.IsSuccessStatusCode;
             }
@@ -248,6 +255,10 @@ namespace Grayjay.Desktop
             bool isFullscreen = args?.Contains("--fullscreen") ?? false;
             double? scaleFactor = args?.FirstOrDefault(a => a.StartsWith("--scale-factor=")) is string s && double.TryParse(s["--scale-factor=".Length..], out var v) ? v : null;
 
+            string? startupUrl = args?.FirstOrDefault(a => a.StartsWith("grayjay://https://") || a.StartsWith("grayjay://http://"));
+            if (startupUrl != null)
+                startupUrl = startupUrl.Substring("grayjay://".Length);
+
 #if DEBUG
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                 WindowsAPI.AllocConsole();
@@ -293,7 +304,7 @@ namespace Grayjay.Desktop
 
                 if (await WaitForPortFileAndProcess())
                 {
-                    if (await TryOpenWindow())
+                    if (await TryOpenWindow(startupUrl))
                     {
                         Logger.i<Program>("Successfully opened new window, closing current process.");
                         return;
@@ -315,7 +326,7 @@ namespace Grayjay.Desktop
 
             if (File.Exists(PortFile))
             {
-                if (await TryOpenWindow())
+                if (await TryOpenWindow(startupUrl))
                 {
                     Logger.i<Program>("Successfully opened new window, closing current process.");
                     return;
@@ -475,6 +486,9 @@ namespace Grayjay.Desktop
             File.Delete(StartingUpFile);
             File.WriteAllText(PortFile, server.BaseUri!.Port.ToString());
             Logger.i<Program>("Created PortFile, removed StartingUpFile");
+
+            if (startupUrl != null)
+                StateWebsocket.PendingStartupUrl = startupUrl;
 
             Logger.i(nameof(Program), "Main: Navigate.");
             if (window != null)

--- a/Grayjay.Desktop.Installer/Grayjay.wxs
+++ b/Grayjay.Desktop.Installer/Grayjay.wxs
@@ -54,10 +54,23 @@
 		</DirectoryRef>
 		
 				 
+		<DirectoryRef Id="APPLICATIONROOTDIRECTORY">
+			<Component Id="GrayjayProtocol" Guid="b3f2a1c4-8e7d-4f9a-b6c2-1d3e5f7a9b0c">
+				<RegistryKey Root="HKCR" Key="grayjay">
+					<RegistryValue Type="string" Value="URL:Grayjay Protocol" KeyPath="yes" />
+					<RegistryValue Name="URL Protocol" Type="string" Value="" />
+				</RegistryKey>
+				<RegistryKey Root="HKCR" Key="grayjay\shell\open\command">
+					<RegistryValue Type="string" Value="&quot;[APPLICATIONROOTDIRECTORY]Grayjay.exe&quot; &quot;%1&quot;" />
+				</RegistryKey>
+			</Component>
+		</DirectoryRef>
+
 		<Feature Id="MainApplication" Title="Grayjay" Level="1">
 			<ComponentRef Id="Files" />
 			<ComponentRef Id="FilesCEF" />
 			<ComponentRef Id="ApplicationShortcut" />
+			<ComponentRef Id="GrayjayProtocol" />
 		</Feature>
 		
 		<CustomAction Id="RunUpdaterEXE"

--- a/app.grayjay.Grayjay.desktop
+++ b/app.grayjay.Grayjay.desktop
@@ -7,6 +7,7 @@ Comment=Universal media aggregator
 Categories=AudioVideo;Player;
 
 Icon=app.grayjay.Grayjay
-Exec=Grayjay
+Exec=Grayjay %u
 Terminal=false
 StartupWMClass=cef
+MimeType=x-scheme-handler/grayjay;


### PR DESCRIPTION
## Summary

   - Registers the `grayjay://` URI scheme on all platforms: Linux (`.desktop` file `MimeType`), macOS (`Info.plist` `CFBundleURLTypes`), and Windows (WiX installer `HKCR` registry keys)
   - Adds startup logic in `Program.cs` to extract a `grayjay://https://...` URL from command-line args and route it to the frontend once the app is ready
   - Extends `TryOpenWindow` to also call a new `/Window/OpenUrl` endpoint when Grayjay is already running, so the URL is delivered without spawning a second instance
   - Adds `StateWebsocket.PendingStartupUrl` so the URL is held until the frontend signals ready via `/Window/Ready`, avoiding a race condition on cold start

   ## Motivation

   This enables CLI scripts (e.g. `xdg-open "grayjay://www.youtube.com/watch?v=CHcb7_MEDKQ"`) and browser extensions (e.g. [Redirector](https://github.com/einaregilsson/Redirector),  [LibRedirect](https://github.com/libredirect/browser_extension)) to redirect links directly into Grayjay, the same way [FreeTube](https://github.com/FreeTubeApp/FreeTube) handles `freetube://` links. When a user enters a URL prefixed with  `grayjay://` the OS hands it to Grayjay, and the video opens automatically.