### PR TITLE
Fix SIGINT not closing Grayjay in headless/server mode

### DIFF
--- a/Grayjay.Desktop.CEF/Program.cs
+++ b/Grayjay.Desktop.CEF/Program.cs
@@ -443,8 +443,21 @@ namespace Grayjay.Desktop
             //Logger.i(nameof(Program), $"Main: EnableClient finished ({watch.ElapsedMilliseconds}ms)");
 
             CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
-            GrayjayServer server = new GrayjayServer((!isServer && cef != null ? new CEFWindowProvider(cef) : null), 
-                isHeadless, 
+
+            Console.CancelKeyPress += (sender, e) =>
+            {
+                e.Cancel = true; // Prevent immediate termination; handle gracefully below
+                Logger.i(nameof(Program), "Received SIGINT, shutting down gracefully.");
+                cancellationTokenSource.Cancel();
+            };
+
+            AppDomain.CurrentDomain.ProcessExit += (sender, e) =>
+            {
+                cancellationTokenSource.Cancel();
+            };
+
+            GrayjayServer server = new GrayjayServer((!isServer && cef != null ? new CEFWindowProvider(cef) : null),
+                isHeadless,
                 isServer);
             _ = Task.Run(async () =>
             {


### PR DESCRIPTION
## Summary
   - Fixes #569
   - Registers a `Console.CancelKeyPress` handler that cancels the shared `CancellationTokenSource` on SIGINT (Ctrl+C), rather than letting the signal propagate unhandled
   - Registers an `AppDomain.CurrentDomain.ProcessExit` handler for the same token to cover SIGTERM
   - This unblocks `WaitHandle.WaitOne()` in headless/server mode (and `WaitForExitAsync` in windowed mode), allowing the cleanup sequence to run and the process to exit gracefully

