### PR TITLE
feat(subscriptions): subscription group management enhancements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -398,3 +398,9 @@ FodyWeavers.xsd
 
 # JetBrains Rider
 *.sln.iml
+
+# Steam zip
+Grayjay_Steam.zip
+
+# Audit local (résultats d'audit de code, jamais à committer)
+audits/

--- a/Grayjay.Desktop.Web/src/overlays/OverlaySubscriptionGroupEdit/index.tsx
+++ b/Grayjay.Desktop.Web/src/overlays/OverlaySubscriptionGroupEdit/index.tsx
@@ -30,6 +30,8 @@ const OverlaySubscriptionGroupEditDialog: Component<OverlaySubscriptionGroupEdit
     const [selected$, setSelected] = createSignal<string[]>([]);
 
     const [stateView$, setStateView] = createSignal(0);
+    const [isMoveMode$, setMoveMode] = createSignal(false);
+    const [groups$] = createResourceDefault(async () => SubscriptionsBackend.subscriptionGroups());
 
     function select(sub: ISubscription) {
       const index = selected.indexOf(sub.channel.url);
@@ -74,6 +76,24 @@ const OverlaySubscriptionGroupEditDialog: Component<OverlaySubscriptionGroupEdit
       changeView(0);
       props.subscriptionGroup.urls = props.subscriptionGroup.urls.concat(arr).filter(onlyUnique);
       subscriptionsResource.refetch();
+    }
+
+    function selectAll() {
+      const groupSubs = subscriptions$()?.filter(x => props.subscriptionGroup.urls.indexOf(x.channel.url) >= 0) ?? [];
+      const allSelected = selected$().length === groupSubs.length;
+      selected.length = 0;
+      if(!allSelected) selected.push(...groupSubs.map(s => s.channel.url));
+      setSelected([...selected]);
+    }
+
+    function copyToGroup(targetGroupId: string) {
+      const target = groups$()?.find(g => g.id === targetGroupId);
+      if(!target) return;
+      target.urls = [...new Set([...target.urls, ...selected$()])];
+      SubscriptionsBackend.subscriptionGroupSave(target);
+      if(isMoveMode$()) deleteSelected();
+      else setSelected([]);
+      changeView(0);
     }
 
     function globalBack() {
@@ -125,6 +145,34 @@ const OverlaySubscriptionGroupEditDialog: Component<OverlaySubscriptionGroupEdit
                     onPress: () => deleteGroup(),
                     onBack: globalBack
                   }} />
+            </div>
+          </div>
+        </Show>
+        <Show when={stateView$() == 4}>
+          <div class={styles.container} use:focusScope={{ initialMode: 'trap' }} onClick={(ev) => ev.stopPropagation()} onMouseDown={(ev) => ev.stopPropagation()}>
+            <div class={styles.dialogHeader}>
+              <div class={styles.headerText}>{isMoveMode$() ? "Move to group" : "Copy to group"}</div>
+              <div class={styles.headerSubText}>Select the destination group</div>
+            </div>
+            <ScrollContainer>
+              <div style={{"margin-left": "20px", "margin-right": "20px", "height": "65vh"}}>
+                <div class={styles.subscriptionsContainer}>
+                  <For each={groups$()?.filter(g => g.id !== props.subscriptionGroup.id)}>{(group) =>
+                    <div class={styles.subscription} onClick={() => copyToGroup(group.id)} use:focusable={{
+                      onPress: () => copyToGroup(group.id),
+                      onBack: globalBack
+                    }}>
+                      <div class={styles.image} style={{"background-image": `url(${proxyImageVariable(group.image)})`}} />
+                      <div class={styles.name}>{group.name}</div>
+                    </div>
+                  }</For>
+                </div>
+              </div>
+            </ScrollContainer>
+            <div style="height: 1px; background-color: rgba(255, 255, 255, 0.09); margin-top: 10px; margin-bottom: 10px;"></div>
+            <div style="text-align: right">
+              <Button text={"Cancel"} onClick={() => changeView(0)} style={{"margin-left": "10px", cursor: "pointer"}}
+                color={"#222"} focusableOpts={{ onPress: () => changeView(0), onBack: globalBack }} />
             </div>
           </div>
         </Show>
@@ -189,10 +237,26 @@ const OverlaySubscriptionGroupEditDialog: Component<OverlaySubscriptionGroupEdit
             </ScrollContainer>
             <div style="height: 1px; background-color: rgba(255, 255, 255, 0.09); margin-top: 10px; margin-bottom: 10px;"></div>
             <div style="text-align: right">
+                  <Button
+                    text={selected$().length > 0 && selected$().length === (subscriptions$()?.filter(x => props.subscriptionGroup.urls.indexOf(x.channel.url) >= 0).length ?? 0) ? "Deselect All" : "Select All"}
+                    onClick={() => selectAll()}
+                    style={{"margin-left": "10px", cursor: "pointer"}}
+                    color={"#222"}
+                    focusableOpts={{ onPress: () => selectAll(), onBack: globalBack }} />
                   <Show when={selected$().length > 0}>
+                    <Button text={"Copy to group"}
+                      onClick={() => { setMoveMode(false); changeView(4); }}
+                      style={{"margin-left": "10px", cursor: "pointer"}}
+                      color={"#222"}
+                      focusableOpts={{ onPress: () => { setMoveMode(false); changeView(4); }, onBack: globalBack }} />
+                    <Button text={"Move to group"}
+                      onClick={() => { setMoveMode(true); changeView(4); }}
+                      style={{"margin-left": "10px", cursor: "pointer"}}
+                      color={"#222"}
+                      focusableOpts={{ onPress: () => { setMoveMode(true); changeView(4); }, onBack: globalBack }} />
                     <Button text={"Delete Selected"}
                       onClick={()=>deleteSelected()}
-                      style={{"margin-left": "10px", cursor: ("pointer")}} 
+                      style={{"margin-left": "10px", cursor: ("pointer")}}
                       color={"rgba(249, 112, 102, 0.08)"}
                       focusableOpts={{
                         onPress: () => deleteSelected(),

--- a/Grayjay.Desktop.Web/src/pages/Subscriptions/index.tsx
+++ b/Grayjay.Desktop.Web/src/pages/Subscriptions/index.tsx
@@ -1,4 +1,4 @@
-import { createSignal, type Component, For, createResource, Show, createEffect, createMemo } from 'solid-js';
+import { createSignal, type Component, For, createResource, Show, createEffect, createMemo, Accessor, untrack } from 'solid-js';
 import styles from './index.module.css';
 import { SubscriptionsBackend } from '../../backend/SubscriptionsBackend';
 import SearchBar from '../../components/topbars/SearchBar';
@@ -100,9 +100,9 @@ const SubscriptionsPage: Component = () => {
   });
   createEffect(()=>{
     const ids = selectedGroups$();
-    console.log("Group changed: " + ids.join(","));
-    subGroupPagerResource.refetch();
-    if(ids.length > 1 && !(subPager$.state == "ready" && subPager$()?.hadInitialUpdate$()))
+    if(ids.length === 1)
+      subGroupPagerResource.refetch();
+    if(ids.length > 1 && untrack(() => !(subPager$.state == "ready" && subPager$()?.hadInitialUpdate$())))
       subPagerResource.refetch();
   });
   const currentPager$ = createMemo(()=>{

--- a/Grayjay.Desktop.Web/src/pages/Subscriptions/index.tsx
+++ b/Grayjay.Desktop.Web/src/pages/Subscriptions/index.tsx
@@ -55,7 +55,7 @@ const SubscriptionsPage: Component = () => {
   
   let [selectedCreators$, setSelectedCreators] = createSignal<string[]>([]);
   const hasSelectedCreator$ = createMemo(()=> selectedCreators$() && selectedCreators$().length > 0);
-  let [selectedGroup$, setSelectedGroup] = createSignal<string>();
+  let [selectedGroups$, setSelectedGroups] = createSignal<string[]>([]);
 
   StateWebsocket.registerHandlerNew("subProgress", (packet)=>{
     setSubProgress(packet.payload.progress / packet.payload.total);
@@ -84,11 +84,11 @@ const SubscriptionsPage: Component = () => {
     return subscriptionPager;
   });
   const [subGroupPager$, subGroupPagerResource] = createResourceDefault(async () => {
-    const id = selectedGroup$();
-    if(!id)
+    const ids = selectedGroups$();
+    if(ids.length !== 1)
       return undefined;
 
-    return await SubscriptionsBackend.subscriptionGroupPager(id, false);
+    return await SubscriptionsBackend.subscriptionGroupPager(ids[0], false);
   });
   const [filterPager$, filterPagerResource] = createResourceDefault(async () => {
     const url = selectedCreators$();
@@ -99,11 +99,15 @@ const SubscriptionsPage: Component = () => {
     return filterPager;
   });
   createEffect(()=>{
-    console.log("Group changed: " + selectedGroup$());
+    const ids = selectedGroups$();
+    console.log("Group changed: " + ids.join(","));
     subGroupPagerResource.refetch();
+    if(ids.length > 1 && !(subPager$.state == "ready" && subPager$()?.hadInitialUpdate$()))
+      subPagerResource.refetch();
   });
   const currentPager$ = createMemo(()=>{
-    if(!selectedGroup$()) {
+    const groups = selectedGroups$();
+    if(groups.length === 0) {
       if(selectedCreators$() && selectedCreators$().length > 0 && filterPager$.state == "ready") {
         const filterPagerResult = filterPager$();
         return filterPagerResult;
@@ -113,8 +117,14 @@ const SubscriptionsPage: Component = () => {
       else
         return subCachePager$();
     }
-    else
+    else if(groups.length === 1)
       return subGroupPager$();
+    else {
+      if(subPager$.state == "ready" && subPager$()?.hadInitialUpdate$())
+        return subPager$();
+      else
+        return subCachePager$();
+    }
   });
   createEffect(()=>{
     const pager = currentPager$();
@@ -165,7 +175,15 @@ const SubscriptionsPage: Component = () => {
       updateFilter(pager, getFilter());
   }
   function getFilter() {
+    const groups = selectedGroups$();
+    let groupChannelIds: Set<string> | null = null;
+    if(groups.length > 1) {
+      const groupUrls = new Set((subGroups$() ?? []).filter(g => groups.includes(g.id)).flatMap(g => g.urls));
+      groupChannelIds = new Set((subs$() ?? []).filter(sub => groupUrls.has(sub.channel.url)).map(sub => sub.channel.id.value));
+    }
     return (obj: IPlatformContent)=>{
+      if(groupChannelIds && !groupChannelIds.has(obj.author.id.value))
+        return false;
       //const creators = selectedCreators$();
       //if(creators.length > 0 && creators.indexOf(obj.author.url) < 0)
       //  return false;
@@ -210,6 +228,14 @@ const SubscriptionsPage: Component = () => {
       if(pager)
         updateFilter(pager, getFilter());
       */
+  }
+
+  function toggleGroup(groupId: string, multi: boolean) {
+    const ids = selectedGroups$();
+    if(multi)
+      setSelectedGroups(ids.includes(groupId) ? ids.filter(x => x !== groupId) : [...ids, groupId]);
+    else
+      setSelectedGroups(ids.length === 1 && ids[0] === groupId ? [] : [groupId]);
   }
 
   function updateFilter(pager: Pager<IPlatformContent>, condition: (obj: IPlatformContent)=>boolean){
@@ -327,49 +353,58 @@ const SubscriptionsPage: Component = () => {
               </div>
             </Show>
             <Show when={hasSubGroups$()}>
-                <div class={styles.subgroups} style={{
-                  height: subGroupsExpanded$() ? undefined : '86px',
-                  overflow: 'hidden'
-                }}>
-                  <div 
-                    class={styles.subGroupExpand} 
-                    onClick={()=>setSubGroupsExpanded(!subGroupsExpanded$())}
-                    use:focusable={{ onPress: () => setSubGroupsExpanded(!subGroupsExpanded$()) }}
+              <div class={styles.subgroups}>
+                <For each={subGroups$()}>{(subGroup: ISubscriptionGroup, i: Accessor<number>) => (
+                  <div
+                    class={styles.subgroup}
+                    classList={{ [styles.active]: selectedGroups$().includes(subGroup.id) }}
+                    onClick={(e) => toggleGroup(subGroup.id, e.metaKey || e.ctrlKey)}
+                    use:focusable={{
+                      groupEscapeTo: {
+                        left: ['sidebar'],
+                        down: ['filters'],
+                        up: ['creators']
+                      },
+                      groupId: 'subgroups',
+                      groupType: 'horizontal',
+                      groupIndices: [i()],
+                      onOptions: () => UIOverlay.overlayEditSubscriptionGroup(subGroup),
+                      onPress: () => toggleGroup(subGroup.id, false)
+                    }}
                   >
-                    <Show when={subGroupsExpanded$()}>
-                      <img src={iconChevUp} />
-                    </Show>
-                    <Show when={!subGroupsExpanded$()}>
-                      <img src={iconChevDown} />
-                    </Show>
+                    <div
+                      class={styles.image}
+                      style={{ "background-image": `url(${proxyImageVariable(subGroup.image)})` }}
+                    />
+                    <img
+                      class={styles.editIcon}
+                      src={iconEdit}
+                      onClick={(ev) => { UIOverlay.overlayEditSubscriptionGroup(subGroup); ev.stopPropagation(); }}
+                    />
+                    <div class={styles.name}>{subGroup.name}</div>
                   </div>
-                  <For each={subGroups$()}>{(subGroup: ISubscriptionGroup, i) =>
-                    <div 
-                      class={styles.subgroup} 
-                      classList={{[styles.active]: subGroup.id == selectedGroup$() }} 
-                      onClick={()=>(subGroup.id == selectedGroup$()) ? setSelectedGroup(undefined) : setSelectedGroup(subGroup.id)}
-                      use:focusable={{ onOptions: () => UIOverlay.overlayEditSubscriptionGroup(subGroup), onPress: () => (subGroup.id == selectedGroup$()) ? setSelectedGroup(undefined) : setSelectedGroup(subGroup.id) }}
-                    >
-                      <div class={styles.image} style={{"background-image": "url(" + proxyImageVariable(subGroup.image) + ")"}} />
-                      
-                      <img class={styles.editIcon} src={iconEdit} onClick={(ev)=>{ UIOverlay.overlayEditSubscriptionGroup(subGroup); ev.stopPropagation()}} />
-                      <div class={styles.name}>
-                        {subGroup.name}
-                      </div>
-                    </div>
-                  }</For>
-                  <div 
-                    class={styles.subgroup} 
-                    style="cursor: pointer" 
-                    onClick={()=>newSubscriptionGroup()}
-                    use:focusable={{ onPress: () => newSubscriptionGroup() }}
-                  >
-                    <div class={styles.image} style={{"background": "#222"}} />
-                    <div class={styles.centerText}>
-                      New Group
-                    </div>
-                  </div>
+                )}</For>
+
+                <div
+                  class={styles.subgroup}
+                  style="cursor: pointer"
+                  onClick={() => newSubscriptionGroup()}
+                  use:focusable={{
+                    groupEscapeTo: {
+                      left: ['sidebar'],
+                      down: ['filters'],
+                      up: ['creators']
+                    },
+                    groupId: 'subgroups',
+                    groupType: 'horizontal',
+                    groupIndices: [subGroups$()?.length ?? 0],
+                    onPress: () => newSubscriptionGroup()
+                  }}
+                >
+                  <div class={styles.image} style={{ background: "#222" }} />
+                  <div class={styles.centerText}>New Group</div>
                 </div>
+              </div>
             </Show>
             <Show when={!!filters}>
               <div class={styles.filters}>


### PR DESCRIPTION
## Summary

- **Multi-select groups**: Cmd/Ctrl+click to select multiple subscription groups simultaneously; content is filtered across all selected groups
- **Select All / Deselect All**: batch selection buttons in the group edit overlay
- **Copy to group**: copy subscriptions from one group to another without removing them from the source
- **Move to group**: move subscriptions from one group to another (removes from source)
- **Memory fix**: wrapped reactive reads in `untrack()` inside `createEffect` to prevent unintended reactive loops

## Files changed

- `src/pages/Subscriptions/index.tsx` — multi-select logic, `toggleGroup()`, `untrack()` fix, conditional refetch
- `src/overlays/OverlaySubscriptionGroupEdit/index.tsx` — Select All / Deselect All, Copy to group, Move to group