### PR TITLE
Fix subscription refresh cache fallback and peek classification

### DIFF
--- a/Grayjay.ClientServer/Subscriptions/Algorithms/SmartSubscriptionAlgorithm.cs
+++ b/Grayjay.ClientServer/Subscriptions/Algorithms/SmartSubscriptionAlgorithm.cs
@@ -88,7 +88,7 @@ namespace Grayjay.ClientServer.Subscriptions.Algorithms
                         else
                         {
                             if (peekTasks.Count < 100 && GrayjaySettings.Instance.Subscriptions.PeekChannelContents &&
-                                task.Sub.LastPeekVideo.Year < 1971 || task.Sub.LastPeekVideo < task.Sub.LastVideoUpdate &&
+                                (task.Sub.LastPeekVideo.Year < 1971 || task.Sub.LastPeekVideo < task.Sub.LastVideoUpdate) &&
                                 task.Client.Capabilities.HasPeekChannelContents && task.Client.GetPeekChannelTypes().Contains(task.Type))
                             {
                                 task.FromPeek = true;

--- a/Grayjay.ClientServer/Subscriptions/Algorithms/SubscriptionsTaskFetchAlgorithm.cs
+++ b/Grayjay.ClientServer/Subscriptions/Algorithms/SubscriptionsTaskFetchAlgorithm.cs
@@ -318,12 +318,12 @@ namespace Grayjay.ClientServer.Subscriptions.Algorithms
                                 SetProgress(finished, forkTasks.Count);
                                 if (!cachedChannels.Contains(task.Url))
                                 {
-                                    return new SubscriptionTaskResult(task, null, null);
+                                    cachedChannels.Add(task.Url);
+                                    return new SubscriptionTaskResult(task, StateCache.GetChannelCachePager(task.Url), null);
                                 }
                                 else
                                 {
-                                    cachedChannels.Add(task.Url);
-                                    return new SubscriptionTaskResult(task, StateCache.GetChannelCachePager(task.Url), null);
+                                    return new SubscriptionTaskResult(task, null, null);
                                 }
                             }
                         }
@@ -334,7 +334,6 @@ namespace Grayjay.ClientServer.Subscriptions.Algorithms
                             return new SubscriptionTaskResult(task, null, null); //skipped
                         }
 
-                        Exception taskEx = null;
                         IPager<PlatformContent> pager = null;
                         try
                         {
@@ -390,8 +389,7 @@ namespace Grayjay.ClientServer.Subscriptions.Algorithms
                             {
                                 Logger.i(nameof(StateSubscriptions), $"Channel {task.Sub.Channel.Name} failed, substituting with cache");
                                 pager = StateCache.GetChannelCachePager(task.Sub.Channel.Url);
-                                taskEx = ex;
-                                return new SubscriptionTaskResult(task, pager, taskEx);
+                                return new SubscriptionTaskResult(task, pager, null);
                             }
                         }
                     });
@@ -411,13 +409,13 @@ namespace Grayjay.ClientServer.Subscriptions.Algorithms
                                 SetProgress(finished, forkTasks.Count);
                                 if (!cachedChannels.Contains(task.Url))
                                 {
-                                    source.SetResult(new SubscriptionTaskResult(task, null, null));
+                                    cachedChannels.Add(task.Url);
+                                    source.SetResult(new SubscriptionTaskResult(task, StateCache.GetChannelCachePager(task.Url), null));
                                     return;
                                 }
                                 else
                                 {
-                                    cachedChannels.Add(task.Url);
-                                    source.SetResult(new SubscriptionTaskResult(task, StateCache.GetChannelCachePager(task.Url), null));
+                                    source.SetResult(new SubscriptionTaskResult(task, null, null));
                                     return;
                                 }
                             }
@@ -430,7 +428,6 @@ namespace Grayjay.ClientServer.Subscriptions.Algorithms
                             return;
                         }
 
-                        Exception taskEx = null;
                         IPager<PlatformContent> pager = null;
                         try
                         {
@@ -487,8 +484,7 @@ namespace Grayjay.ClientServer.Subscriptions.Algorithms
                             {
                                 Logger.i(nameof(StateSubscriptions), $"Channel {task.Sub.Channel.Name} failed, substituting with cache");
                                 pager = StateCache.GetChannelCachePager(task.Sub.Channel.Url);
-                                taskEx = ex;
-                                source.SetResult(new SubscriptionTaskResult(task, pager, taskEx));
+                                source.SetResult(new SubscriptionTaskResult(task, pager, null));
                                 return;
                             }
                         }


### PR DESCRIPTION
Correct cached subscription task deduplication so the first cached task for a channel contributes its cache pager and later duplicate cache tasks are skipped.

Avoid propagating exceptions from successful cache fallback results, preventing one transient channel/network failure from aborting collection of the remaining subscription refresh results.

Also fix peek-task classification precedence so the peek setting and client capability checks apply consistently.

Related to #922
Related to #915
May also help #880
May also help #539
May also help #544