### PR TITLE
feat: support dynamic Peertube source icons via grayjay-plugin-peertube implementation

### DIFF
--- a/Grayjay.ClientServer/Controllers/SourcesController.cs
+++ b/Grayjay.ClientServer/Controllers/SourcesController.cs
@@ -26,6 +26,23 @@ namespace Grayjay.ClientServer.Controllers
 
 
         [HttpGet]
+        public string GetDynamicIcon(string id)
+        {
+            var plugin = StatePlatform.GetClient(id);
+            if (plugin == null) return null;
+
+            try
+            {
+                // Call the dynamic getIcon method implemented in the plugin script
+                return plugin.CallMethod("getIcon");
+            }
+            catch (Exception ex)
+            {
+                Logger.e(nameof(SourcesController), "Failed to call getIcon for plugin [" + id + "]: " + ex.Message);
+                return null;
+            }
+        }
+        [HttpGet]
         public PluginConfig[] Sources()
         {
             return StatePlatform.GetAvailableClients().Select(x => x.Config).ToArray();

--- a/Grayjay.Desktop.Web/src/backend/SourcesBackend.ts
+++ b/Grayjay.Desktop.Web/src/backend/SourcesBackend.ts
@@ -78,6 +78,10 @@ export abstract class SourcesBackend {
     static async sourceInstallPeerTubePrompt(url: string): Promise<IPluginPrompt> {
         return await Backend.POST("/sources/SourceInstallPeerTubePrompt", JSON.stringify(url), "application/json") as any;
     }
+
+    static async getDynamicIcon(id: string): Promise<string | null> {
+        return await Backend.GET("/sources/GetDynamicIcon?id=" + id) as string;
+    }
     
     static login(id: string) {
         Backend.GET("/sources/SourceLogin?id=" + id);

--- a/Grayjay.Desktop.Web/src/backend/models/plugin/ISourceConfigState.ts
+++ b/Grayjay.Desktop.Web/src/backend/models/plugin/ISourceConfigState.ts
@@ -75,8 +75,9 @@ export interface ISourceConfig {
     version: number;
     author: string;
     authorUrl: string;
-    iconUrl: string;
+    iconUrl: string; // <--- Static icon URL read directly from the plugin's JSON config file
     sourceUrl: string;
+    scriptUrl: string;
     scriptUrl: string;
     allowUrls: string[];
     packages: string[];
@@ -91,7 +92,7 @@ export interface ISourceConfig {
     supportedClaimTypes: number[];
     primaryClaimFieldType: number;
     settings: ISourceSetting[];
-    absoluteIconUrl?: string;
+    absoluteIconUrl?: string; // <--- Computed absolute URL derived from the static iconUrl above
     absoluteScriptUrl?: string;
 }
 

--- a/Grayjay.Desktop.Web/src/pages/Sources/index.tsx
+++ b/Grayjay.Desktop.Web/src/pages/Sources/index.tsx
@@ -168,9 +168,11 @@ const SourcesPage: Component = () => {
                             }}>
                               <img src={iconThumb} />
                             </div>
-                            <div class={styles.image}>
-                              <img src={StateGlobal.getSourceConfig(source()!.id)?.absoluteIconUrl} />
-                            </div>
+                               <div class={styles.image}>
+                                 {/* Try dynamic icon from plugin.getIcon(), fallback to static absoluteIconUrl (derived from JSON iconUrl) */}
+                                 <img src={StateGlobal.getDynamicIcon(source()!.id).then(icon => icon ?? StateGlobal.getSourceConfig(source()!.id)?.absoluteIconUrl)} />
+                               </div>
+
                             <div class={styles.name}>
                               {source()!.name}
                             </div>
@@ -198,9 +200,11 @@ const SourcesPage: Component = () => {
                       groupRememberLast: true,
                       onPress: () => enableSource(source)
                     }}>
-                      <div class={styles.image}>
-                        <img src={StateGlobal.getSourceConfig(source.id)?.absoluteIconUrl} />
-                      </div>
+                       <div class={styles.image}>
+                         {/* Try dynamic icon from plugin.getIcon(), fallback to static absoluteIconUrl (derived from JSON iconUrl) */}
+                         <img src={StateGlobal.getDynamicIcon(source.id).then(icon => icon ?? StateGlobal.getSourceConfig(source.id)?.absoluteIconUrl)} />
+                       </div>
+
                       <div class={styles.name}>
                         {source.name}
                       </div>

--- a/Grayjay.Desktop.Web/src/state/StateGlobal.tsx
+++ b/Grayjay.Desktop.Web/src/state/StateGlobal.tsx
@@ -33,7 +33,8 @@ export interface StateGlobal {
     getSourceConfig: (id: string | undefined) => ISourceConfig | undefined,
     getSourceState: (id: string | undefined) => ISourceConfigState | undefined,
     getCommonSearchCapabilities: (sourceIds: string[]) => IResultCapabilities | undefined,
-    getCommonSearchChannelContentsCapabilities: (sourceIds: string[]) => IResultCapabilities | undefined
+    getCommonSearchChannelContentsCapabilities: (sourceIds: string[]) => IResultCapabilities | undefined,
+    getDynamicIcon: (id: string) => Promise<string | null>
 };
 
 function createState() {
@@ -173,6 +174,9 @@ function createState() {
             if(!id)
                 return undefined;
             return sourceStates$()?.find(x=>x.config.id == id);
+        },
+        getDynamicIcon(id: string) {
+            return SourcesBackend.getDynamicIcon(id);
         },
         getCommonSearchCapabilities(sourceIds: string[]): IResultCapabilities | undefined {
             return getCommonSearchCapabilitiesType(sourceIds, (sourceId) => this.getSourceState(sourceId)?.capabilitiesSearch);


### PR DESCRIPTION
# feat: support dynamic Peertube source icons via grayjay-plugin-peertube implementation

## Summary

Currently, source icons are static and derived solely from the `iconUrl` defined in the plugin's configuration JSON. While this works for general purposes, it doesn't allow plugins to provide dynamic icons based on the specific instance configuration.

This PR introduces a mechanism to fetch dynamic icons by calling a `getIcon()` method directly from the plugin implementation if available.

## Changes
- **Backend**: Added a new endpoint `/sources/GetDynamicIcon` in `SourcesController` that invokes the `getIcon` method of the target plugin.
- **Frontend**:
    - Integrated `getDynamicIcon` into `SourcesBackend` and `StateGlobal`.
    - Updated the Sources page and related components to attempt fetching the dynamic icon first.
    - Implemented a fallback mechanism: if the dynamic icon is unavailable or the plugin does not implement the method, it reverts to the static `absoluteIconUrl` (derived from the JSON `iconUrl`).

### Use Case: PeerTube
This is specifically designed to support the PeerTube plugin, allowing it to display the actual icon configured on the peer-to-peer instance.
The plugin-side implementation of this feature can be found in this PR:
👉 https://github.com/futo-org/grayjay-plugin-peertube/pull/3

### Testing
- Verified that sources with a `getIcon` method now display their dynamic icon.
- Verified that sources without the method still display their static config icon correctly.
