### PR TITLE
Tolerate reordered PlatformContent cache JSON

### DIFF
--- a/Grayjay.ClientServer/Controllers/SubscriptionsController.cs
+++ b/Grayjay.ClientServer/Controllers/SubscriptionsController.cs
@@ -106,9 +106,21 @@ namespace Grayjay.ClientServer.Controllers
         [HttpGet]
         public async Task<PagerResult<PlatformVideo>> SubscriptionsCacheLoad()
         {
-            var subs = StateCache.GetSubscriptionCachePager();
-            this.State().SubscriptionsState.SubscriptionPagerCache = subs;
-            return subs.AsPagerResult(x => x is PlatformVideo, y => StateHistory.AddVideoMetadata((PlatformVideo)y));
+            try
+            {
+                var subs = StateCache.GetSubscriptionCachePager();
+                this.State().SubscriptionsState.SubscriptionPagerCache = subs;
+                return subs.AsPagerResult(x => x is PlatformVideo, y => StateHistory.AddVideoMetadata((PlatformVideo)y));
+            }
+            catch (Exception ex)
+            {
+                return new PagerResult<PlatformVideo>()
+                {
+                    Results = new PlatformVideo[0],
+                    HasMore = false,
+                    Exception = ex.Message
+                };
+            }
         }
         [HttpGet]
         public PagerResult<PlatformVideo> SubscriptionsCacheNextPage()

--- a/Grayjay.ClientServer/Serializers/PlatformContentConverter.cs
+++ b/Grayjay.ClientServer/Serializers/PlatformContentConverter.cs
@@ -18,27 +18,54 @@ namespace Grayjay.ClientServer.Serializers
             Utf8JsonReader readerClone = reader;
 
             if (readerClone.TokenType != JsonTokenType.StartObject)
-                throw new JsonException();
+                throw new JsonException("Expected object");
 
-            readerClone.Read();
-            if (readerClone.TokenType != JsonTokenType.PropertyName)
-                throw new JsonException();
-
-            string? propertyName = readerClone.GetString();
-            if (propertyName != nameof(PlatformContent.ContentType))
-                throw new JsonException();
-
-            readerClone.Read();
-            if (readerClone.TokenType != JsonTokenType.Number)
-                throw new JsonException();
-
-            ContentType typeDiscriminator = (ContentType)readerClone.GetInt32();
+            ContentType typeDiscriminator = ReadContentType(ref readerClone);
             PlatformContent content = typeDiscriminator switch
             {
                 ContentType.MEDIA => JsonSerializer.Deserialize<PlatformVideo>(ref reader)!,
                 _ => JsonSerializer.Deserialize<PlatformContent>(ref reader)
             };
             return content;
+        }
+
+        private static ContentType ReadContentType(ref Utf8JsonReader reader)
+        {
+            while (reader.Read())
+            {
+                if (reader.TokenType == JsonTokenType.EndObject)
+                    break;
+                if (reader.TokenType != JsonTokenType.PropertyName)
+                    throw new JsonException("Expected property");
+
+                string? propertyName = reader.GetString();
+                if (!reader.Read())
+                    throw new JsonException("Expected property value");
+
+                if (propertyName != null && propertyName.Equals(nameof(PlatformContent.ContentType), StringComparison.OrdinalIgnoreCase))
+                    return ReadContentTypeValue(ref reader);
+
+                reader.Skip();
+            }
+
+            throw new JsonException("Expected property ContentType");
+        }
+
+        private static ContentType ReadContentTypeValue(ref Utf8JsonReader reader)
+        {
+            if (reader.TokenType == JsonTokenType.Number && reader.TryGetInt32(out int intValue))
+                return (ContentType)intValue;
+
+            if (reader.TokenType == JsonTokenType.String)
+            {
+                string? stringValue = reader.GetString();
+                if (int.TryParse(stringValue, out int parsedInt))
+                    return (ContentType)parsedInt;
+                if (Enum.TryParse(stringValue, true, out ContentType parsedEnum))
+                    return parsedEnum;
+            }
+
+            throw new JsonException("Expected numeric or string ContentType");
         }
 
         public override void Write(Utf8JsonWriter writer, PlatformContent value, JsonSerializerOptions options)

--- a/Grayjay.Desktop.Tests/PlatformContentConverterTests.cs
+++ b/Grayjay.Desktop.Tests/PlatformContentConverterTests.cs
@@ -1,0 +1,38 @@
+using System.Text.Json;
+using Grayjay.ClientServer.Serializers;
+using Grayjay.Engine.Models.Feed;
+
+namespace Grayjay.Desktop.Tests
+{
+    [TestClass]
+    public class PlatformContentConverterTests
+    {
+        [TestMethod]
+        public void Deserialize_PlatformVideo_WhenContentTypeIsNotFirstProperty()
+        {
+            var options = new JsonSerializerOptions();
+            options.Converters.Add(new PlatformContentConverter());
+
+            const string json = """
+            {
+                "Description": "Plugin-specific metadata before the discriminator",
+                "ContentType": 1,
+                "Name": "Example video",
+                "Author": {
+                    "Name": "Example channel",
+                    "Url": "https://example.com/channel"
+                },
+                "Url": "https://example.com/video",
+                "Duration": 120,
+                "ViewCount": 42
+            }
+            """;
+
+            var content = JsonSerializer.Deserialize<PlatformContent>(json, options);
+
+            Assert.IsInstanceOfType(content, typeof(PlatformVideo));
+            Assert.AreEqual("Example video", content!.Name);
+            Assert.AreEqual("https://example.com/video", content.Url);
+        }
+    }
+}


### PR DESCRIPTION
## Problem
Cached subscription items can fail to deserialize when the `PlatformContent.ContentType` discriminator is not the first property in the JSON object. When that happens, cached subscription content may not be available during the initial page load.

## Summary
- Read `PlatformContent.ContentType` from anywhere in the serialized object instead of requiring it to be the first property.
- Accept numeric and string discriminator values before deserializing cached media as `PlatformVideo`.
- Return an empty pager result with the exception message if subscription cache loading still fails, matching the existing next-page error handling.

## Testing
- `dotnet build Grayjay.Desktop.CEF/Grayjay.Desktop.CEF.csproj -c Release`
- `dotnet test Grayjay.Desktop.Tests/Grayjay.Desktop.Tests.csproj --filter PlatformContentConverterTests` (blocked by existing `ProxyTests.cs` compile errors; `ProxyTests.cs` is unchanged by this PR)
