### PR TITLE
Log subscription exchange status instead of showing toast

### DIFF
--- a/Grayjay.ClientServer/Subscriptions/Algorithms/SubscriptionsTaskFetchAlgorithm.cs
+++ b/Grayjay.ClientServer/Subscriptions/Algorithms/SubscriptionsTaskFetchAlgorithm.cs
@@ -173,7 +173,7 @@ namespace Grayjay.ClientServer.Subscriptions.Algorithms
                         if (resolve != null)
                         {
                             resolveCount = resolves.Length;
-                            StateUI.Toast($"SubsExchange (Res: {resolves.Length}, Prov: {resolve.Length})");
+                            Logger.i(TAG, $"SubsExchange resolved (Res: {resolves.Length}, Prov: {resolve.Length})");
                             foreach (var result in resolve)
                             {
                                 var task = providedTasks?.FirstOrDefault(x => x.Url == result.ChannelUrl);


### PR DESCRIPTION
## Problem
During subscription refreshes, an internal subscription exchange diagnostic message can be shown to users as a toast, for example `SubsExchange (Res: ..., Prov: ...)`.

## Summary
- Replace the subscription exchange debug toast with a server log entry.
- Keep the existing resolve/provide counts available for diagnostics without showing an internal status message to users during subscription refreshes.

## Testing
- `dotnet build Grayjay.Desktop.CEF/Grayjay.Desktop.CEF.csproj -c Release`
