### PR TITLE
fix(db): create SQLite indexes for [Indexed] columns

### DIFF
--- a/Grayjay.ClientServer/Database/DatabaseConnection.cs
+++ b/Grayjay.ClientServer/Database/DatabaseConnection.cs
@@ -117,6 +117,26 @@ namespace Grayjay.ClientServer.Database
                 string tableQuery = $"CREATE TABLE {tq}\n({string.Join(",\n", definitions)})";
                 SQL((x) => x.Execute(tableQuery));
             }
+
+            // Create an index for every property marked [Indexed]. Uses
+            // IF NOT EXISTS so it also repairs existing databases whose table
+            // predates this: the [Indexed] attribute was declared on columns
+            // like subscriptionCache.Url/ChannelUrl but never actually created,
+            // leaving large tables unindexed and forcing a full table scan on
+            // every lookup (very slow startup for users with big caches).
+            var indexedProperties = properties
+                .Where(x => x.GetCustomAttribute<IndexedAttribute>() != null);
+            foreach (var prop in indexedProperties)
+            {
+                var ordering = prop.GetCustomAttribute<IndexedAttribute>()!.Ordering switch
+                {
+                    Ordering.Ascending => " ASC",
+                    Ordering.Descending => " DESC",
+                    _ => ""
+                };
+                var indexName = Quote($"idx_{table}_{prop.Name}");
+                SQL((x) => x.Execute($"CREATE INDEX IF NOT EXISTS {indexName} ON {tq} ({Quote(prop.Name)}{ordering})"));
+            }
         }
         private string GetSQLType(Type type)
         {


### PR DESCRIPTION
The `[Indexed]` attribute on DB index models (e.g. `subscriptionCache.Url`, `ChannelUrl`, `DateTime`) is declared but never honored: `DatabaseConnection.EnsureTable` creates the table and its columns, but no indexes. Every lookup therefore does a full table scan.

For heavy users this becomes severe. On a real profile the `subscriptionCache` table had grown to **58,894 rows / 118 MB**. On startup the subscription refresh runs a per-item dedup query (`Query` by `Url`) and a per-channel query (`QueryPager` by `ChannelUrl`), each of which full-scans the whole table thousands of times. Measured result: about 3.4s of dead time per subscription, roughly 5-6 minutes total, during which the app looks frozen on launch.

Root cause: `DatabaseConnection.EnsureTable` never reads `IndexedAttribute`.

Fix: after ensuring a table exists, create `CREATE INDEX IF NOT EXISTS` for every `[Indexed]` property (respecting `Ordering`). It is idempotent, so it also repairs existing databases created before the index existed.

Verified with `EXPLAIN QUERY PLAN`: the affected queries go from `SCAN subscriptionCache` to `SEARCH ... USING INDEX`, and startup drops from minutes to seconds.
