### PR TITLE
Fix Linux CEF library discovery

### DIFF
--- a/Grayjay.Desktop.CEF/Program.cs
+++ b/Grayjay.Desktop.CEF/Program.cs
@@ -26,6 +26,32 @@ namespace Grayjay.Desktop
         private const int StartupTimeoutSeconds = 5;
         private const int NewWindowTimeoutSeconds = 5;
 
+        private static void EnsureCefLibraryPath()
+        {
+            if (!OperatingSystem.IsLinux())
+                return;
+
+            string? cefDirectory = Utilities.FindDirectory("cef");
+            if (string.IsNullOrEmpty(cefDirectory))
+            {
+                Logger.w(nameof(Program), "Unable to locate the CEF directory");
+                return;
+            }
+
+            string? currentPath = Environment.GetEnvironmentVariable("LD_LIBRARY_PATH");
+            string[] paths = string.IsNullOrEmpty(currentPath)
+                ? Array.Empty<string>()
+                : currentPath.Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries);
+
+            if (!paths.Contains(cefDirectory, StringComparer.Ordinal))
+            {
+                string updatedPath = string.IsNullOrEmpty(currentPath)
+                    ? cefDirectory
+                    : cefDirectory + Path.PathSeparator + currentPath;
+                Environment.SetEnvironmentVariable("LD_LIBRARY_PATH", updatedPath);
+            }
+        }
+
         private static bool IsProcessRunningByPath(string path, out Process? matchingProcess)
         {
             matchingProcess = null;
@@ -383,6 +409,7 @@ namespace Grayjay.Desktop
             using var cef = !isServer ? new JustCefProcess() : null;
             if (cef != null)
             {
+                EnsureCefLibraryPath();
                 PackageBrowser.Process = cef;
                 Stopwatch startWindowWatch = Stopwatch.StartNew();
                 var extraArgs = ReconstructArgs(args);


### PR DESCRIPTION
## What changed

On Linux, prepend Grayjay's bundled `cef/` directory to `LD_LIBRARY_PATH` before starting the CEF process.

## Why

CEF's ANGLE backend loads EGL libraries with `dlopen()` at runtime. The bundled `libEGL.so` is next to `justcefnative`, but that directory is not guaranteed to be present in the dynamic loader's search path. When it cannot resolve EGL, the CEF subprocess exits during startup and Grayjay remains on a blank/gray window.

The path is added only on Linux, preserves the existing value, and is inherited by CEF's browser and GPU subprocesses.

## Validation

- `dotnet restore Grayjay.Desktop.CEF/Grayjay.Desktop.CEF.csproj`
- `dotnet build Grayjay.Desktop.CEF/Grayjay.Desktop.CEF.csproj --no-restore -v:q`

The build completed successfully with 0 errors. Existing compiler/analyzer warnings remain unchanged.
