### PR TITLE
Add Mark as watched to video menus

### DIFF
--- a/Grayjay.ClientServer/Controllers/HistoryController.cs
+++ b/Grayjay.ClientServer/Controllers/HistoryController.cs
@@ -66,6 +66,12 @@ namespace Grayjay.ClientServer.Controllers
         }
 
 
+        [HttpPost]
+        public bool MarkAsWatched([FromBody] PlatformVideo video)
+        {
+            return StateHistory.MarkAsWatched(video);
+        }
+
         [HttpGet]
         public bool RemoveHistory(string url)
         {

--- a/Grayjay.ClientServer/States/StateHistory.cs
+++ b/Grayjay.ClientServer/States/StateHistory.cs
@@ -174,6 +174,29 @@ namespace Grayjay.ClientServer.States
             return result;
         }
 
+        public static bool MarkAsWatched(PlatformVideo video)
+        {
+            if (video == null)
+                return false;
+
+            try
+            {
+                var history = GetHistoryByVideo(video, true, DateTime.Now);
+                if (history == null)
+                    return false;
+
+                long position = Math.Max(1, video.Duration - 1);
+                UpdateHistory(video, history, position, 0);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                Logger.e(nameof(StateHistory), "Failed to mark as watched", ex);
+                StateUI.Toast("Failed to mark as watched\n" + ex.Message);
+                return false;
+            }
+        }
+
 
         public static void RemoveHistory(string url)
         {

--- a/Grayjay.Desktop.Web/src/Menus.tsx
+++ b/Grayjay.Desktop.Web/src/Menus.tsx
@@ -7,14 +7,24 @@ import ic_addToPlaylist from './assets/icons/icon_add_to_playlist.svg';
 import ic_subscriptions from './assets/icons/icon_nav_subscriptions.svg';
 import ic_download from './assets/icons/icon24_download.svg';
 import ic_trash from './assets/icons/icon_trash.svg';
+import ic_history from './assets/icons/icon_nav_history.svg';
 
 import { ISourceConfigState } from "./backend/models/plugin/ISourceConfigState";
 import UIOverlay from "./state/UIOverlay";
 import { PlaylistsBackend } from "./backend/PlaylistsBackend";
 import { IPlaylist } from "./backend/models/IPlaylist";
 import { SubscriptionsBackend } from "./backend/SubscriptionsBackend";
+import { IPlatformVideo } from "./backend/models/content/IPlatformVideo";
+import { HistoryBackend } from "./backend/HistoryBackend";
 
 export class Menus {
+    static markAsWatchedButton(video: IPlatformVideo, onMarked?: () => void) {
+        return new MenuItemButton("Mark as watched", ic_history, undefined, async () => {
+            await HistoryBackend.markAsWatched(video);
+            onMarked?.();
+        });
+    }
+
     static getSubscriptionMenu(subscription: ISubscription, subscriptionSettings: ISubscriptionSettings, sourceState?: ISourceConfigState) {
         const hasStreams = (sourceState?.capabilitiesChannel?.types?.indexOf("STREAMS") ?? -1) !== -1;
         const hasVideos = (sourceState?.capabilitiesChannel?.types?.indexOf("VIDEOS") ?? -1) !== -1 

--- a/Grayjay.Desktop.Web/src/backend/HistoryBackend.ts
+++ b/Grayjay.Desktop.Web/src/backend/HistoryBackend.ts
@@ -1,5 +1,6 @@
 import { Backend } from "./Backend";
 import { IHistoryVideo } from "./models/content/IHistoryVideo";
+import { IPlatformVideo } from "./models/content/IPlatformVideo";
 import { Pager } from "./models/pagers/Pager";
 
 export abstract class HistoryBackend {
@@ -24,6 +25,26 @@ export abstract class HistoryBackend {
     }
     static async historyPager(): Promise<Pager<IHistoryVideo>> {
         return Pager.fromMethods<IHistoryVideo>(this.historyLoad, this.historyNextPage);
+    }
+
+    static watchedPosition(duration: number): number {
+        return Math.max(1, (duration ?? 0) - 1);
+    }
+
+    static applyWatchedMetadata(video: IPlatformVideo): void {
+        const videoAny = video as IPlatformVideo & { metadata?: { position?: number, watched?: boolean } };
+        videoAny.metadata = {
+            ...(videoAny.metadata ?? {}),
+            position: this.watchedPosition(video.duration),
+            watched: true
+        };
+    }
+
+    static async markAsWatched(video: IPlatformVideo): Promise<boolean> {
+        const result = await Backend.POST("/history/MarkAsWatched", JSON.stringify(video), "application/json") as boolean;
+        if (result)
+            this.applyWatchedMetadata(video);
+        return result;
     }
 
     static async removeHistory(url: string): Promise<boolean> {

--- a/Grayjay.Desktop.Web/src/backend/models/pagers/Pager.ts
+++ b/Grayjay.Desktop.Web/src/backend/models/pagers/Pager.ts
@@ -80,6 +80,26 @@ export abstract class Pager<T> {
         
     }
 
+    itemUpdated(item: T) {
+        const dataIndex = this.data.indexOf(item);
+        const filteredIndex = this.dataFiltered.indexOf(item);
+        const copy = { ...(item as object) } as T;
+        if (dataIndex >= 0)
+            this.data[dataIndex] = copy;
+        if (filteredIndex >= 0)
+            this.dataFiltered[filteredIndex] = copy;
+
+        if (this.filter) {
+            this.setFilter(this.filter);
+            return;
+        }
+
+        if (dataIndex >= 0)
+            this.modified(dataIndex, dataIndex);
+        if (filteredIndex >= 0)
+            this.modifiedFiltered(filteredIndex, filteredIndex);
+    }
+
     protected modified(startIndex: number, endIndex: number){
         this.modifiedItemsEvent.invoke({ startIndex, endIndex });
         console.log("modified triggered", {startIndex, endIndex});

--- a/Grayjay.Desktop.Web/src/components/PlaylistDetailView/index.tsx
+++ b/Grayjay.Desktop.Web/src/components/PlaylistDetailView/index.tsx
@@ -69,6 +69,7 @@ const PlaylistDetailView: Component<PlaylistDetailViewProps> = (props) => {
       title: "",
       items: [
         new MenuItemButton("Add to queue", iconQueue, undefined, () => props.onAddToQueue(content)),
+        Menus.markAsWatchedButton(content),
         new MenuItemButton("Add to playlist", iconAddToPlaylist, undefined, async () => {
           await UIOverlay.overlayAddToPlaylist(content, () => props.refetch?.());
         }),

--- a/Grayjay.Desktop.Web/src/components/containers/ContentGrid/index.tsx
+++ b/Grayjay.Desktop.Web/src/components/containers/ContentGrid/index.tsx
@@ -14,6 +14,7 @@ import iconAddToPlaylist from '../../../assets/icons/icon24_add_to_playlist.svg'
 import iconHide from '../../../assets/icons/icon24_hide.svg';
 import iconDownload from '../../../assets/icons/icon24_download.svg';
 import iconCreator from '../../../assets/icons/icon_nav_creators.svg';
+import { Menus } from "../../../Menus";
 import Anchor, { AnchorStyle } from "../../../utility/Anchor";
 import { Portal } from "solid-js/web";
 import { WatchLaterBackend } from "../../../backend/WatchLaterBackend";
@@ -103,6 +104,9 @@ const ContentGrid: Component<ContentGridProps> = (props) => {
                     new MenuItemButton("Watch later", iconWatchLater, undefined, async () => {
                         await WatchLaterBackend.add(content as IPlatformVideo);
                         await video?.actions?.refetchWatchLater();
+                    }),
+                    Menus.markAsWatchedButton(content as IPlatformVideo, () => {
+                        props.pager?.itemUpdated(content);
                     }),
                     new MenuItemButton("Add to playlist", iconAddToPlaylist, undefined, async () => {
                         await UIOverlay.overlayAddToPlaylist(content as IPlatformVideo);

--- a/Grayjay.Desktop.Web/src/pages/Downloads/index.tsx
+++ b/Grayjay.Desktop.Web/src/pages/Downloads/index.tsx
@@ -53,6 +53,7 @@ import { WatchLaterBackend } from '../../backend/WatchLaterBackend';
 import { focusable } from '../../focusable'; void focusable;
 import Button from '../../components/buttons/Button';
 import { InputSource } from '../../nav';
+import { Menus } from '../../Menus';
 
 const DownloadsPage: Component = () => {
   const navigate = useNavigate();
@@ -284,6 +285,7 @@ const DownloadsPage: Component = () => {
                       await WatchLaterBackend.add(content as any as IPlatformVideo);
                       await video?.actions?.refetchWatchLater();
                   }),
+                  Menus.markAsWatchedButton(content as any as IPlatformVideo),
                   new MenuItemButton("Add to playlist", iconAddToPlaylist, undefined, async () => {
                       await UIOverlay.overlayAddToPlaylist(content as any as IPlatformVideo);
                   })

--- a/Grayjay.Desktop.Web/src/pages/History/index.tsx
+++ b/Grayjay.Desktop.Web/src/pages/History/index.tsx
@@ -30,6 +30,7 @@ import { Pager } from '../../backend/models/pagers/Pager';
 import { focusable } from "../../focusable"; void focusable;
 import SkeletonDiv from '../../components/basics/loaders/SkeletonDiv';
 import { useFocus } from '../../FocusProvider';
+import { Menus } from '../../Menus';
 
 const HistoryPage: Component = () => {
   const focus = useFocus();
@@ -134,6 +135,10 @@ const HistoryPage: Component = () => {
               setShow(false);
               await WatchLaterBackend.add(content.video);
               await video?.actions?.refetchWatchLater();
+            }),
+            Menus.markAsWatchedButton(content.video, () => {
+              content.position = HistoryBackend.watchedPosition(content.video.duration);
+              historyPager$()?.itemUpdated(content);
             }),
             new MenuItemButton("Add to playlist", iconAddToPlaylist, undefined, async () => {
               setShow(false);

--- a/Grayjay.Desktop.Web/src/pages/Playlists/index.tsx
+++ b/Grayjay.Desktop.Web/src/pages/Playlists/index.tsx
@@ -61,6 +61,7 @@ const PlaylistsPage: Component = () => {
       new MenuItemButton("Add to queue", iconQueue, undefined, () => {
 
       }),
+      Menus.markAsWatchedButton(content),
       new MenuItemButton("Add to playlist", iconAddToPlaylist, undefined, async () => {
         await UIOverlay.overlayAddToPlaylist(content, () => playlistsResource.refetch());
       }),


### PR DESCRIPTION
Attempting to port the Android "Add to History" action so videos can be added to history without playing them, which also feeds the subscriptions watched filter.

I tested this locally on my Fedora 44 machine, and it appears to work well. I was able to mark items as watched, see them in the history tab, see that the "Watched" filter in the subscription tab filters them out, and check that videos played normally are still added to the history tab too.

This was developed using Cursor. I'm not too sure what your AI usage policy is though, so I figured I'd make it clear that this was AI generated

<img width="1430" height="1108" alt="Screenshot_20260818_162808" src="https://github.com/user-attachments/assets/d18f96d6-4828-4725-bfa0-6f2effcebb35" />
(excuse the news as the example, just showing the new drop-down menu option)

Fixes #81 

I'm also happy to update this to rename the button to "Add to History" if desired, but I personally feel like "Mark as watched" is a little easier to parse